### PR TITLE
chore: add Copilot cloud sandbox setup (hve-core-all + devcontainer)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Kea (.NET 7 + Node)",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-7.0-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "postCreateCommand": "dotnet restore Kea.sln && bash .devcontainer/setup-hve-core.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "GitHub.copilot"
+      ]
+    }
+  }
+}

--- a/.devcontainer/setup-hve-core.sh
+++ b/.devcontainer/setup-hve-core.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install the GitHub Copilot CLI and hve-core-all plugin.
+# Best-effort and non-fatal — the sandbox starts even if this fails.
+set -euo pipefail
+
+echo "==> Setting up hve-core-all Copilot CLI plugin..."
+
+command -v copilot >/dev/null 2>&1 \
+  || npm install -g @github/copilot \
+  || echo "::warning::copilot CLI install failed"
+
+copilot plugin marketplace add microsoft/hve-core \
+  || echo "::warning::marketplace add failed"
+
+copilot plugin install hve-core-all@hve-core \
+  || echo "::warning::hve-core-all install failed"
+
+copilot plugin list || true
+
+echo "==> hve-core-all setup complete (errors above are non-fatal)."

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,54 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up .NET 7
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "7.0.x"
+
+      - name: Set up Node.js (LTS)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Restore .NET dependencies
+        run: dotnet restore Kea.sln
+        continue-on-error: true
+
+      - name: Install hve-core-all plugin
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash .devcontainer/setup-hve-core.sh
+        continue-on-error: true
+
+      - name: Verify tools
+        run: |
+          echo "=== .NET SDK ===" && dotnet --version
+          echo "=== Node ===" && node --version
+          echo "=== npm ===" && npm --version
+          echo "=== Copilot CLI ===" && (copilot --version 2>/dev/null || echo "copilot CLI not found")

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,8 +33,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
-          cache: "npm"
-          cache-dependency-path: "**/package-lock.json"
 
       - name: Restore .NET dependencies
         run: dotnet restore Kea.sln


### PR DESCRIPTION
## What was added

Three files to set up a GitHub Copilot cloud sandbox for this repo, including the `hve-core-all` Copilot CLI plugin from [microsoft/hve-core](https://github.com/microsoft/hve-core):

| File | Purpose |
|------|---------|
| `.devcontainer/setup-hve-core.sh` | Shared, idempotent install script for the Copilot CLI + hve-core-all plugin |
| `.devcontainer/devcontainer.json` | Dev container definition (image + Node feature + postCreateCommand) |
| `.github/workflows/copilot-setup-steps.yml` | Copilot cloud-sandbox setup workflow |

## Detected stack

| Dimension | Value |
|-----------|-------|
| Primary language | C# |
| Framework | ASP.NET Core (Minimal API) |
| Target framework | `net7.0` |
| Solution file | `Kea.sln` |
| Project file | `kea.web/kea.web.csproj` |
| Also present | Python loader (`kea.src/src/loader/`), Bicep IaC (`kea.bicep/`) |
| Action-pinning convention | Tag refs (`@v3`, `@v4`) — not SHA-pinned |

## Build / test / lint commands

```bash
# Restore
dotnet restore Kea.sln

# Build
dotnet build Kea.sln

# Test (no test projects currently defined)
# dotnet test Kea.sln
```

No lint tool is currently configured in CI. The existing `dependency-review.yml` workflow uses `actions/checkout@v3` and `actions/dependency-review-action@v2` (tag refs).

## hve-core-all install result

**Result: Non-blocking / best-effort only** — the install script is designed to succeed regardless of authentication state.

The install steps (`npm install -g @github/copilot`, `copilot plugin marketplace add`, `copilot plugin install hve-core-all@hve-core`) all use `|| echo "::warning::..."` fallbacks, so a sandbox starts even when the Copilot CLI requires auth or network access is restricted.

When credentials are available (`GITHUB_TOKEN` is passed as an env var), the workflow step "Install hve-core-all plugin" will run `bash .devcontainer/setup-hve-core.sh` and `copilot plugin list` will confirm the plugin is installed:

```
hve-core-all@hve-core (v3.x.x)
```

If authentication is required but not satisfied, the expected output is:

```
::warning::copilot CLI install failed
::warning::marketplace add failed
::warning::hve-core-all install failed
```

The workflow step has `continue-on-error: true`, so the overall job still passes.

## Validation

- **actionlint**: Workflow validated locally — correct `on:`, `permissions:`, and step structure.
- **devcontainer.json**: Valid JSON using `mcr.microsoft.com/devcontainers/dotnet:1-7.0-bullseye` base + Node LTS feature.
- **setup-hve-core.sh**: Script is idempotent (`command -v copilot` check) and all install steps are non-fatal.

---
*No existing code was modified. Three files added only.*